### PR TITLE
Remove `steps` block when call reusable workflow

### DIFF
--- a/content/actions/using-workflows/reusing-workflows.md
+++ b/content/actions/using-workflows/reusing-workflows.md
@@ -112,10 +112,10 @@ You can define inputs and secrets, which can be passed from the caller workflow 
      reusable_workflow_job:
        runs-on: ubuntu-latest
        environment: production
-       - uses: ./.github/workflows/my-action
-         with:
-           username: ${{ inputs.username }}
-           token: ${{ secrets.envPAT }}
+       uses: ./.github/workflows/my-action
+       with:
+         username: ${{ inputs.username }}
+         token: ${{ secrets.envPAT }}
    ```
    {% endraw %}
    In the example above, `envPAT` is an environment secret that's been added to the `production` environment. This environment is therefore referenced within the job.

--- a/content/actions/using-workflows/reusing-workflows.md
+++ b/content/actions/using-workflows/reusing-workflows.md
@@ -112,11 +112,10 @@ You can define inputs and secrets, which can be passed from the caller workflow 
      reusable_workflow_job:
        runs-on: ubuntu-latest
        environment: production
-       steps:
-         - uses: ./.github/workflows/my-action
-           with:
-             username: ${{ inputs.username }}
-             token: ${{ secrets.envPAT }}
+       - uses: ./.github/workflows/my-action
+         with:
+           username: ${{ inputs.username }}
+           token: ${{ secrets.envPAT }}
    ```
    {% endraw %}
    In the example above, `envPAT` is an environment secret that's been added to the `production` environment. This environment is therefore referenced within the job.


### PR DESCRIPTION
### Why:

Wrong example code.
Can not use `steps` block when calling reusable workflow.

If use steps block when call reusable workflow, error occurred follows:

```
Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/path/to/workflow.yml'. Did you forget to run actions/checkout before running your local action?
```

refs https://github.community/t/actions-reusable-workflow-failing-to-find-action-yml-that-does-exist/231258


<!--
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. If you made changes to the `content` directory, a table will populate in a comment below with the staging and live article links -->

### Check off the following:

- [ ] I have reviewed my changes in staging (look for "Automatically generated comment" and click **Modified** to view your latest changes).
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).

### Writer impact (This section is for GitHub staff members only):

- [ ] This pull request impacts the contribution experience
  - [ ] I have added the 'writer impact' label
  - [ ] I have added a description and/or a video demo of the changes below (e.g. a "before and after video")

<!-- Description of the writer impact here -->
